### PR TITLE
fix: Correct logout redirect path

### DIFF
--- a/auth/logout.php
+++ b/auth/logout.php
@@ -22,7 +22,7 @@ session_destroy();
 
 // Arahkan pengguna kembali ke halaman utama (landing page)
 // Menggunakan path absolut dari root web server untuk kejelasan
-$root_path = '/'; // Sesuaikan jika aplikasi berada di subdirektori
+$root_path = '/Help_HazelWebOnlineVote2/'; // Sesuaikan jika aplikasi berada di subdirektori
 header("Location: " . $root_path . "index.php");
 exit;
 ?>


### PR DESCRIPTION
This commit fixes the logout redirect functionality to point to the correct subdirectory.

- Modifies `auth/logout.php` to ensure the redirect URL includes the `/Help_HazelWebOnlineVote2/` path, leading you back to the correct landing page.